### PR TITLE
Minor tweaks and bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 * A progress bar mimicking the time slider in the video controls
 * Clicking the progress bar will adjust the video's current time intuitively.
 * Time elapsed and total video duration are displayed in minutes:seconds
-* When the video has ten seconds or less remaining, an "up next" notification appears in the bottom-right, displaying the next video's title.
+* When the video has eight seconds or less remaining, an notification appears in the bottom-right, displaying the next video's title.
 * When the video ends, it plays the next video in queue.
 
 #### Video sources:

--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,7 @@ class App extends Component {
     super();
     this.state = {
       timeElapsed: 0,
-      timeRemaining: 0,
+      timeRemaining: 10,
       videoDuration: 0,
       currentVideoIdx: 0,
       nextVideoIdx: 1,
@@ -35,17 +35,17 @@ class App extends Component {
   updateVideoDuration = (e) => {
     this.setState({
       videoDuration: e.target.duration,
+      videoDurationMinutes: Math.floor(e.target.duration / 60),
+      videoDurationSeconds: Math.floor(e.target.duration) % 60,
     })
   }
 
-  updateDurations = (e) => {
+  updateTimeElapsed = (e) => {
     this.setState({
       timeElapsed: e.target.currentTime,
       timeRemaining: e.target.duration - e.target.currentTime,
       timeElapsedMinutes: Math.floor(e.target.currentTime / 60),
       timeElapsedSeconds: Math.floor(e.target.currentTime) % 60,
-      videoDurationMinutes: Math.floor(e.target.duration / 60),
-      videoDurationSeconds: Math.floor(e.target.duration) % 60,
     });
   }
 
@@ -78,7 +78,7 @@ class App extends Component {
           height="auto"
           width={`${progressBarWidth}`}
           src={videoSource}
-          onTimeUpdate={this.updateDurations}
+          onTimeUpdate={this.updateTimeElapsed}
           onPlay={this.updateVideoDuration}
           onEnded={this.updateCurrentlyPlayingVideo}
           controls
@@ -91,7 +91,7 @@ class App extends Component {
         <p className="videoTimeDisplay">
           {this.state.timeElapsedMinutes}:{this.state.timeElapsedSeconds}/{this.state.videoDurationMinutes}:{this.state.videoDurationSeconds}
         </p>
-        {this.state.timeRemaining <= 10 ? <p className="upNext">up next: {nextVideoTitle}</p> : null}
+        {this.state.timeRemaining <= 8 ? <p className="upNext">Next Video: {nextVideoTitle}</p> : null}
       </div>
     );
   }


### PR DESCRIPTION
  * reduced "next" notification threshold to eight seconds,
    * updated readme to reflect this
  * fixed bug that caused "next" notification to appear on initial
    video render
    * assigned a default value to timeRemaining state  that's higher
      than eight seconds
  * fixed bug where video duration does shows NaN:NaN on initial
    video render
    * moved state updates for videoDurationMinutes and
      videoDurationSeconds to the onPlay handler