### PR TITLE
Fixed bug in custom video player

### DIFF
--- a/src/CustomVideoPlayer.js
+++ b/src/CustomVideoPlayer.js
@@ -66,12 +66,20 @@ class CustomVideoPlayer extends Component {
 
   toggleFullScreen = () => {
     if (document.webkitIsFullScreen) {
-      this.setState({ inFullScreen: false });
       document.webkitExitFullscreen();
     } else {
-      this.setState({ inFullScreen: true });
       this.state.playerWrapper.webkitRequestFullScreen();
     }
+
+    const maxProgressBar = document.getElementById('controlsMaxProgressBar');
+
+    this.setState({
+      inFullScreen: !document.webkitIsFullScreen,
+    }, () => {
+      setTimeout(() => {
+        this.setState({ currentProgressWidth: (maxProgressBar.offsetWidth/this.state.videoDuration) * this.state.timeElapsed, })
+      }, 100);
+    });
   }
 
   togglePlayPause = () => {


### PR DESCRIPTION
  * The bug prevented the orange progress bar from resizing correctly
    while the video is paused and user toggles between fullscreen and
    non-fullscreen mode.
  * The fix involved adding a delayed state update for
    `currentProgressWidth` to give the browser enough time to resize
    the `controlsMaxProgressBar` div.
  * DRY'd up the `toggleFullScreen` logic for good measure.